### PR TITLE
Add missing Foundation import

### DIFF
--- a/GraphicsRenderer/Classes/ImageRenderer.swift
+++ b/GraphicsRenderer/Classes/ImageRenderer.swift
@@ -20,6 +20,8 @@
   THE SOFTWARE.
  */
 
+import Foundation
+
 /**
  *  Represents an image renderer format
  */

--- a/GraphicsRenderer/Classes/PDFRenderer.swift
+++ b/GraphicsRenderer/Classes/PDFRenderer.swift
@@ -20,6 +20,8 @@
   THE SOFTWARE.
  */
 
+import Foundation
+
 /**
  *  Represents a PDF renderer format
  */

--- a/GraphicsRenderer/Classes/Renderer.swift
+++ b/GraphicsRenderer/Classes/Renderer.swift
@@ -20,6 +20,8 @@
   THE SOFTWARE.
  */
 
+import Foundation
+
 /**
  Represents a Renderer error
  

--- a/GraphicsRenderer/Classes/RendererDrawable.swift
+++ b/GraphicsRenderer/Classes/RendererDrawable.swift
@@ -20,6 +20,8 @@
   THE SOFTWARE.
  */
 
+import Foundation
+
 extension RendererDrawable {
     
     /// Fills the specified rect


### PR DESCRIPTION
Thanks a lot for the great library! I was trying it out in my Playground targeted macOS, and I noticed that I add to add two lines in order to make it compile: 

```
import Foundation
import AppKit
```
The second import is only in case (would have need to be `import UIKit` if I was targeting iOS. 
I think the `import Foundation` is common to all platforms supported so it should be included by default. Feel free to close the PR if you think otherwise :)