### PR TITLE
Mark UIScreen.mainScreen as nonobjc

### DIFF
--- a/GraphicsRenderer/Classes/Platforms.swift
+++ b/GraphicsRenderer/Classes/Platforms.swift
@@ -50,6 +50,7 @@
     public typealias Screen = UIScreen
 
     extension UIScreen {
+        @nonobjc
         public static var mainScreen: UIScreen {
             return .main
         }


### PR DESCRIPTION
UIScreen inherits NSObject and has a mainScreen property which gets rewritten to .main when interfacing with Swift. However, Platforms.swift fails to compile with error

`method 'mainScreen()' with Objective-C selector 'mainScreen' conflicts with getter for 'mainScreen' with the same Objective-C selector`.

By adding @nonobjc attribute, this isn't exposed to the Objc interface.